### PR TITLE
Update LAB_AK_04_Using_PSProviders_and_PSDrives.md

### DIFF
--- a/Instructions/Labs/LAB_AK_04_Using_PSProviders_and_PSDrives.md
+++ b/Instructions/Labs/LAB_AK_04_Using_PSProviders_and_PSDrives.md
@@ -12,7 +12,7 @@ lab:
 ### Task 1: Create a new folder on a remote computer
 
 1. On **LON-CL1**, select **Start**, and then enter **powersh**.
-1. from the results list, right-click **Windows PowerShell** or activate its context menu, and then select **Run as administrator**.
+1. From the results list, right-click **Windows PowerShell** or activate its context menu, and then select **Run as administrator**.
 1. To review help for the **New-Item** cmdlet in a separate window, in the **Administrator: Windows PowerShell** console, enter the following command, and then press the Enter key:
 
    ```powershell
@@ -20,7 +20,7 @@ lab:
    ```
 
 1. In the output from **Get-Help**, notice the *–Name* and *–ItemType* parameters, then review the example commands, and close te **New-Item Help** window.
-1. To create a new **ScriptShare** folder in **\\\\Lon-Svr1\\C$\\	**, in the console, enter the following command, and then press the Enter key:
+1. To create a new **ScriptShare** folder in **\\\\Lon-Svr1\\C$\\**, in the console, enter the following command, and then press the Enter key:
 
    ```powershell
    New-Item –Path \\Lon-Svr1\C$\ –Name ScriptShare –ItemType Directory


### PR DESCRIPTION
Line 15: Initial capital used for the word "from".
Line 23: Removed the extra space before the second set of asterisk marks in **\\\\Lon-Svr1\\C$\\**.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-