### PR TITLE
Update LAB_04_Using_PSProviders_and_PSDrives.md

### DIFF
--- a/Instructions/Labs/LAB_04_Using_PSProviders_and_PSDrives.md
+++ b/Instructions/Labs/LAB_04_Using_PSProviders_and_PSDrives.md
@@ -20,7 +20,7 @@ After completing this lab, you'll be able to:
 
 ## Estimated time: 30 minutes
 
-## Lab Setup
+## Lab setup
 
 Virtual machines:
 
@@ -83,7 +83,7 @@ The main tasks for this exercise are as follows:
 1. In the **Windows PowerShell** console, enter a command to verify that the registry key **HKEY_CURRENT_USER\Software** does not have a subkey named **Scripts**.
 1. In the console, run a command to create a registry key named **Scripts** in **HKEY_CURRENT_USER\Software**.
 
-### Task 2: Create a new registry setting to store the name of the PSDrive
+### Task 2: Create a new registry value to store the name of the PSDrive
 
 1. In the **Windows PowerShell** console, run a command to set the current working location to the path of the registry key that you created.
 1. Create a registry value to store the PSDrive name with the following configuration:


### PR DESCRIPTION
There are no Exercise 1 results, Exercise 2 results, and Exercise 3 results described. Lab setup includes lab startup information as well. Please check.                                                                                                   Line 23: Changed "Lab Setup" to "Lab setup".                                                                                            
Line 86: Changed "Task 2: Create a new registry value to store the name of the PSDrive" to "Task 2: Create a new registry value to store the name of the PSDrive".

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-