### PR TITLE
Update LAB_AK_04_Using_PSProviders_and_PSDrives.md

### DIFF
--- a/Instructions/Labs/LAB_AK_04_Using_PSProviders_and_PSDrives.md
+++ b/Instructions/Labs/LAB_AK_04_Using_PSProviders_and_PSDrives.md
@@ -90,7 +90,7 @@ lab:
    New-Item –Path HKCU:\Software –Name Scripts
    ```
 
-### Task 2: Create a new registry setting to store the name of the PSDrive
+### Task 2: Create a new registry value to store the name of the PSDrive
 
 1. To change location to **HKCU:\Software\Scripts**, enter the following command, and then press the Enter key:
 


### PR DESCRIPTION
Line 93: Changed "Create a new registry value to store the name of the PSDrive" to "Create a new registry value to store the name of the PSDrive".

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-